### PR TITLE
🧹 Remove Old URLs Endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -242,6 +242,6 @@ func start(_ *cobra.Command, _ []string) {
 	}
 
 	commandGroup := apiGroup.Group("/command", checkUserAdmin)
-	entityGroup.DELETE("/remove-old-links", url.RemoveOlds)
+	commandGroup.DELETE("/remove-old-links", url.RemoveOldIds)
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -240,4 +240,8 @@ func start(_ *cobra.Command, _ []string) {
 			zap.String("listen-address", configuration.CurrentConfig.ListenAddress),
 		)
 	}
+
+	commandGroup := apiGroup.Group("/command", checkUserAdmin)
+	entityGroup.DELETE("/remove-old-links", url.RemoveOlds)
+
 }

--- a/internal/endpoint/url/url.go
+++ b/internal/endpoint/url/url.go
@@ -80,6 +80,29 @@ func Delete(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+func RemoveOldIds(c echo.Context) error {
+	user := c.Get(constrains.UserInfoContextVar).(databasemodels.User)
+
+	// Define cutoff date (6 months ago)
+	cutoff := time.Now().AddDate(0, -1, 0)
+
+	// Prepare query conditions
+	session := database.Engine.Where("last_visited_at < ?", cutoff)
+
+	if !user.Admin {
+		// Non-admins can only delete their own URLs
+		session = session.And("creator_id = ?", user.Id)
+	}
+
+	// Delete matching records
+	_, err := session.Delete(&databasemodels.Url{})
+	if err != nil {
+		return err
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
 func List(c echo.Context) error {
 	user := c.Get(constrains.UserInfoContextVar).(databasemodels.User)
 


### PR DESCRIPTION
Summary
This PR adds a new endpoint RemoveOldIds to the URL package that allows admins to delete old URL entries from the database.

What's Included
Implemented the RemoveOldIds Echo handler.

Deletes URLs that haven't been visited in the last 1 months (last_visited_at < now - 1months).

Admins can delete all old URLs; regular users can only delete their own.

Returns 204 No Content on successful cleanup.

Why
To provide a mechanism for cleaning up outdated or unused URLs, improving storage efficiency and keeping the dataset lean.

Notes
The 1-month threshold is currently hardcoded but can be made configurable later.

The deletion is based on the last_visited_at field.

